### PR TITLE
Update Redis to v8 and use ECR Public Gallery for ECS deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - app-network
 
   redis:
-    image: redis:7-alpine
+    image: redis:8-alpine
     ports:
       - "6379:6379"
     volumes:

--- a/terraform/modules/compute/main.tf
+++ b/terraform/modules/compute/main.tf
@@ -5,7 +5,7 @@ locals {
   # Redis container definition (shared between SSR and API-only configurations)
   redis_container = {
     name      = "redis"
-    image     = "redis:7-alpine"
+    image     = "public.ecr.aws/docker/library/redis:8-alpine"
     essential = false
     # Allocate minimal resources for Redis
     cpu    = var.redis_cpu


### PR DESCRIPTION
- Update Redis from 7-alpine to 8-alpine for latest features
- Switch to public.ecr.aws/docker/library/redis:8-alpine in ECS task definition
- Resolves CannotPullContainerError from private subnets without NAT Gateway
- Maintains consistency between docker-compose and Terraform configurations

🤖 Generated with [Claude Code](https://claude.ai/code)