### PR TITLE
Enable VPC endpoints for ECS private subnet connectivity

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -33,6 +33,9 @@ module "networking" {
   db_subnet_ids            = var.db_subnet_ids
   private_db_subnet_a_cidr = var.private_db_subnet_a_cidr
   private_db_subnet_b_cidr = var.private_db_subnet_b_cidr
+
+  # VPC Endpoints for private subnet internet access
+  create_vpc_endpoints = true
 }
 
 # Security Module


### PR DESCRIPTION
- Add create_vpc_endpoints = true to networking module
- Enables ECR, CloudWatch Logs, Secrets Manager, and S3 access from private subnets
- Resolves container pull timeouts without requiring NAT Gateway
- Cost-effective solution for ECS tasks in private subnets

🤖 Generated with [Claude Code](https://claude.ai/code)