### PR TITLE
Migrate Redis to private ECR repository

### DIFF
--- a/terraform/modules/compute/main.tf
+++ b/terraform/modules/compute/main.tf
@@ -5,7 +5,7 @@ locals {
   # Redis container definition (shared between SSR and API-only configurations)
   redis_container = {
     name      = "redis"
-    image     = "${aws_ecr_repository.redis.repository_url}:8-alpine"
+    image     = "${aws_ecr_repository.redis.repository_url}:${var.redis_version}"
     essential = false
     # Allocate minimal resources for Redis
     cpu    = var.redis_cpu
@@ -86,13 +86,13 @@ resource "aws_ecr_repository" "redis" {
 resource "null_resource" "push_redis_to_ecr" {
   triggers = {
     ecr_repository_url = aws_ecr_repository.redis.repository_url
-    redis_version      = "8-alpine"
+    redis_version      = var.redis_version
     # Trigger re-run only when the push script changes
     script_hash = filemd5("${path.module}/scripts/push-redis-to-ecr.sh")
   }
 
   provisioner "local-exec" {
-    command = "${path.module}/scripts/push-redis-to-ecr.sh ${aws_ecr_repository.redis.name} ${aws_ecr_repository.redis.repository_url} ${var.aws_region} 8-alpine"
+    command = "${path.module}/scripts/push-redis-to-ecr.sh ${aws_ecr_repository.redis.name} ${aws_ecr_repository.redis.repository_url} ${var.aws_region} ${var.redis_version}"
   }
 
   depends_on = [aws_ecr_repository.redis]

--- a/terraform/modules/compute/outputs.tf
+++ b/terraform/modules/compute/outputs.tf
@@ -8,6 +8,11 @@ output "ssr_ecr_repository_url" {
   value       = aws_ecr_repository.ssr.repository_url
 }
 
+output "redis_ecr_repository_url" {
+  description = "URL of the Redis ECR repository"
+  value       = aws_ecr_repository.redis.repository_url
+}
+
 output "ecs_cluster_name" {
   description = "Name of the ECS cluster"
   value       = aws_ecs_cluster.main.name

--- a/terraform/modules/compute/scripts/push-redis-to-ecr.sh
+++ b/terraform/modules/compute/scripts/push-redis-to-ecr.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+# Script to push Redis image to ECR
+# Usage: ./push-redis-to-ecr.sh <repository_name> <repository_url> <aws_region> <redis_version>
+
+REPOSITORY_NAME="$1"
+REPOSITORY_URL="$2"
+AWS_REGION="$3"
+REDIS_VERSION="$4"
+
+if [ -z "$REPOSITORY_NAME" ] || [ -z "$REPOSITORY_URL" ] || [ -z "$AWS_REGION" ] || [ -z "$REDIS_VERSION" ]; then
+  echo "Usage: $0 <repository_name> <repository_url> <aws_region> <redis_version>"
+  exit 1
+fi
+
+echo "Checking if Redis image ${REDIS_VERSION} already exists in ECR..."
+
+# Check if image already exists to avoid unnecessary pushes
+if aws ecr describe-images --repository-name "${REPOSITORY_NAME}" --image-ids imageTag="${REDIS_VERSION}" --region "${AWS_REGION}" >/dev/null 2>&1; then
+  echo "Redis image ${REDIS_VERSION} already exists in ECR, skipping push"
+  exit 0
+fi
+
+echo "Pushing Redis image to ECR..."
+
+# Login to ECR
+aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${REPOSITORY_URL}"
+
+# Pull Redis image from Docker Hub
+docker pull "redis:${REDIS_VERSION}"
+
+# Tag for ECR
+docker tag "redis:${REDIS_VERSION}" "${REPOSITORY_URL}:${REDIS_VERSION}"
+
+# Push to ECR
+docker push "${REPOSITORY_URL}:${REDIS_VERSION}"
+
+echo "Successfully pushed Redis image to ECR"

--- a/terraform/modules/compute/variables.tf
+++ b/terraform/modules/compute/variables.tf
@@ -198,3 +198,14 @@ variable "redis_memory" {
     error_message = "Redis memory allocation is too high for the minimum calculated memory allocation. Reduce redis_memory or increase task_cpu."
   }
 }
+
+variable "redis_version" {
+  description = "Redis Docker image version tag"
+  type        = string
+  default     = "8-alpine"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9.-]+$", var.redis_version))
+    error_message = "Redis version must be a valid Docker tag."
+  }
+}

--- a/terraform/modules/compute/versions.tf
+++ b/terraform/modules/compute/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.99.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2.4"
+    }
   }
 }

--- a/terraform/modules/database/versions.tf
+++ b/terraform/modules/database/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.0"
+      version = "~> 3.2.4"
     }
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -29,6 +29,10 @@ output "ssr_ecr_repository_url" {
   value = module.compute.ssr_ecr_repository_url
 }
 
+output "redis_ecr_repository_url" {
+  value = module.compute.redis_ecr_repository_url
+}
+
 output "ecs_cluster_name" {
   value = module.compute.ecs_cluster_name
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.0"
+      version = "~> 3.2.4"
     }
   }
 }


### PR DESCRIPTION
- Add ECR repository for Redis with KMS encryption and image scanning
- Implement automated Redis image push to ECR using null_resource
- Update ECS task definition to use private ECR Redis image
- Update documentation with ECR setup and deployment details
- Standardize null provider version across modules to ~> 3.2.4

🤖 Generated with [Claude Code](https://claude.ai/code)