### PR TITLE
Fix networking issue

### DIFF
--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -194,28 +194,8 @@ resource "aws_route_table" "private_app" {
   }
 }
 
-# Routes for the private app route table
-# Route for the newly created IGW
-resource "aws_route" "private_app_internet_gateway_new" {
-  count = var.create_private_subnets && var.create_vpc ? 1 : 0
-
-  route_table_id         = aws_route_table.private_app[0].id
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.igw[0].id
-
-  depends_on = [aws_route_table.private_app, aws_internet_gateway.igw]
-}
-
-# Route for the existing IGW
-resource "aws_route" "private_app_internet_gateway_existing" {
-  count = var.create_private_subnets && !var.create_vpc ? 1 : 0
-
-  route_table_id         = aws_route_table.private_app[0].id
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = data.aws_internet_gateway.existing[0].id
-
-  depends_on = [aws_route_table.private_app, data.aws_internet_gateway.existing]
-}
+# Private subnets use VPC endpoints only - no default route to internet
+# This allows ECS tasks to communicate with AWS services without NAT Gateway costs
 
 # Database subnet route table - isolated - only created if create_db_subnets is true
 resource "aws_route_table" "private_db" {

--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -54,3 +54,8 @@ output "interface_endpoints" {
     for name, endpoint in aws_vpc_endpoint.interface : name => endpoint.id
   }
 }
+
+output "private_app_route_table_id" {
+  description = "ID of the private app route table (for testing purposes)"
+  value       = length(aws_route_table.private_app) > 0 ? aws_route_table.private_app[0].id : null
+}

--- a/terraform/modules/networking/variables.tf
+++ b/terraform/modules/networking/variables.tf
@@ -55,25 +55,25 @@ variable "public_subnet_b_cidr" {
 
 # Variables for private app subnets
 variable "create_private_subnets" {
-  description = "Whether to create new private app subnets (true) or use existing ones (false). Private subnets use VPC endpoints only - no internet access or NAT Gateway required."
+  description = "Whether to create new private app subnets (true) or use existing ones (false)"
   type        = bool
   default     = true
 }
 
 variable "private_subnet_ids" {
-  description = "IDs of existing private app subnets to use (if create_private_subnets is false). These subnets must rely on VPC endpoints for AWS service access."
+  description = "IDs of existing private app subnets to use (if create_private_subnets is false)"
   type        = list(string)
   default     = []
 }
 
 variable "private_subnet_a_cidr" {
-  description = "CIDR block for private app subnet in AZ a (if create_private_subnets is true). Will have no default route - VPC endpoints only."
+  description = "CIDR block for private app subnet in AZ a (if create_private_subnets is true)"
   type        = string
   default     = "10.0.3.0/24"
 }
 
 variable "private_subnet_b_cidr" {
-  description = "CIDR block for private app subnet in AZ b (if create_private_subnets is true). Will have no default route - VPC endpoints only."
+  description = "CIDR block for private app subnet in AZ b (if create_private_subnets is true)"
   type        = string
   default     = "10.0.4.0/24"
 }

--- a/terraform/modules/networking/variables.tf
+++ b/terraform/modules/networking/variables.tf
@@ -55,25 +55,25 @@ variable "public_subnet_b_cidr" {
 
 # Variables for private app subnets
 variable "create_private_subnets" {
-  description = "Whether to create new private app subnets (true) or use existing ones (false)"
+  description = "Whether to create new private app subnets (true) or use existing ones (false). Private subnets use VPC endpoints only - no internet access or NAT Gateway required."
   type        = bool
   default     = true
 }
 
 variable "private_subnet_ids" {
-  description = "IDs of existing private app subnets to use (if create_private_subnets is false)"
+  description = "IDs of existing private app subnets to use (if create_private_subnets is false). These subnets must rely on VPC endpoints for AWS service access."
   type        = list(string)
   default     = []
 }
 
 variable "private_subnet_a_cidr" {
-  description = "CIDR block for private app subnet in AZ a (if create_private_subnets is true)"
+  description = "CIDR block for private app subnet in AZ a (if create_private_subnets is true). Will have no default route - VPC endpoints only."
   type        = string
   default     = "10.0.3.0/24"
 }
 
 variable "private_subnet_b_cidr" {
-  description = "CIDR block for private app subnet in AZ b (if create_private_subnets is true)"
+  description = "CIDR block for private app subnet in AZ b (if create_private_subnets is true). Will have no default route - VPC endpoints only."
   type        = string
   default     = "10.0.4.0/24"
 }

--- a/terraform/tests/integration/networking_integration_test.tf
+++ b/terraform/tests/integration/networking_integration_test.tf
@@ -1,0 +1,82 @@
+# Networking Module Integration Test
+# Verifies private app route table has no default route and VPC endpoints work correctly
+
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+# Create the networking module for integration testing
+module "networking_integration_test" {
+  source = "../../modules/networking"
+
+  prefix     = "test-networking-integration"
+  aws_region = "us-east-1"
+
+  create_vpc             = true
+  vpc_cidr               = "10.0.0.0/16"
+  create_public_subnets  = true
+  create_private_subnets = true
+  create_db_subnets      = true
+  create_vpc_endpoints   = true
+}
+
+# Data source to get route table details for assertion
+data "aws_route_table" "private_app_test" {
+  route_table_id = module.networking_integration_test.private_app_route_table_id
+
+  depends_on = [module.networking_integration_test]
+}
+
+# Check to assert that no default route exists
+locals {
+  default_routes = [
+    for route in data.aws_route_table.private_app_test.routes : route
+    if route.destination_cidr_block == "0.0.0.0/0"
+  ]
+
+  has_default_route = length(local.default_routes) > 0
+}
+
+# This check will cause terraform plan/apply to fail if a default route exists
+resource "null_resource" "assert_no_default_route" {
+  count = local.has_default_route ? 1 : 0
+
+  # This will cause an error if count > 0, which happens when has_default_route is true
+  provisioner "local-exec" {
+    command = "echo 'ERROR: Private app route table should not have a default route (0.0.0.0/0)' && exit 1"
+  }
+}
+
+# Output for verification
+output "test_results" {
+  value = {
+    private_app_route_table_id = module.networking_integration_test.private_app_route_table_id
+    total_routes               = length(data.aws_route_table.private_app_test.routes)
+    has_default_route          = local.has_default_route
+    default_routes_count       = length(local.default_routes)
+    vpc_endpoints_created      = module.networking_integration_test.s3_endpoint_id != null
+  }
+}
+
+# Assert that VPC endpoints are created
+resource "null_resource" "assert_vpc_endpoints_created" {
+  count = module.networking_integration_test.s3_endpoint_id == null ? 1 : 0
+
+  provisioner "local-exec" {
+    command = "echo 'ERROR: VPC endpoints should be created for private subnet connectivity' && exit 1"
+  }
+}

--- a/terraform/tests/integration/networking_integration_test.tf
+++ b/terraform/tests/integration/networking_integration_test.tf
@@ -89,11 +89,11 @@ resource "null_resource" "assert_s3_endpoint_created" {
   }
 }
 
-# Assert that interface VPC endpoints are created
+# Assert that exactly 4 interface VPC endpoints are created
 resource "null_resource" "assert_interface_endpoints_created" {
-  count = length(module.networking_integration_test.interface_endpoints) < 4 ? 1 : 0
+  count = length(module.networking_integration_test.interface_endpoints) != 4 ? 1 : 0
 
   provisioner "local-exec" {
-    command = "echo 'ERROR: All required interface VPC endpoints (ECR API, ECR DKR, CloudWatch Logs, Secrets Manager) should be created' && exit 1"
+    command = "echo 'ERROR: Exactly 4 interface VPC endpoints (ECR API, ECR DKR, CloudWatch Logs, Secrets Manager) should be created, got ${length(module.networking_integration_test.interface_endpoints)}' && exit 1"
   }
 }

--- a/terraform/tests/modules/networking_test.go
+++ b/terraform/tests/modules/networking_test.go
@@ -324,19 +324,19 @@ func TestVPCEndpointsConfiguration(t *testing.T) {
 
 	// Check S3 Gateway endpoint
 	s3EndpointID := terraform.Output(t, terraformOptions, "s3_endpoint_id")
-	if s3EndpointID != "" {
-		s3Input := &ec2.DescribeVpcEndpointsInput{
-			VpcEndpointIds: []string{s3EndpointID},
-		}
-		s3Result, err := ec2Client.DescribeVpcEndpoints(context.TODO(), s3Input)
-		assert.NoError(t, err)
-		assert.Len(t, s3Result.VpcEndpoints, 1)
+	assert.NotEmpty(t, s3EndpointID, "S3 Gateway endpoint ID should not be empty")
 
-		s3Endpoint := s3Result.VpcEndpoints[0]
-		assert.Equal(t, vpcID, *s3Endpoint.VpcId)
-		assert.Equal(t, string(types.VpcEndpointTypeGateway), string(s3Endpoint.VpcEndpointType))
-		assert.Contains(t, *s3Endpoint.ServiceName, "s3")
+	s3Input := &ec2.DescribeVpcEndpointsInput{
+		VpcEndpointIds: []string{s3EndpointID},
 	}
+	s3Result, err := ec2Client.DescribeVpcEndpoints(context.TODO(), s3Input)
+	assert.NoError(t, err)
+	assert.Len(t, s3Result.VpcEndpoints, 1)
+
+	s3Endpoint := s3Result.VpcEndpoints[0]
+	assert.Equal(t, vpcID, *s3Endpoint.VpcId)
+	assert.Equal(t, string(types.VpcEndpointTypeGateway), string(s3Endpoint.VpcEndpointType))
+	assert.Contains(t, *s3Endpoint.ServiceName, "s3")
 
 	// Check interface endpoints
 	interfaceEndpoints := terraform.OutputMap(t, terraformOptions, "interface_endpoints")

--- a/terraform/tests/modules/networking_test.go
+++ b/terraform/tests/modules/networking_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	awsgo "github.com/gruntwork-io/terratest/modules/aws"
+	terratestaws "github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
 )
@@ -40,7 +40,7 @@ func TestNetworkingModuleCreatesVPCAndSubnets(t *testing.T) {
 	vpcID := terraform.Output(t, terraformOptions, "vpc_id")
 	assert.NotEmpty(t, vpcID)
 
-	vpc := awsgo.GetVpcById(t, vpcID, testConfig.AWSRegion)
+	vpc := terratestaws.GetVpcById(t, vpcID, testConfig.AWSRegion)
 	// Note: VPC detailed validation simplified due to Terratest API limitations
 	assert.NotNil(t, vpc)
 
@@ -230,7 +230,7 @@ func TestNetworkingModuleValidatesResourceNaming(t *testing.T) {
 
 	// Validate VPC naming
 	vpcID := terraform.Output(t, terraformOptions, "vpc_id")
-	vpc := awsgo.GetVpcById(t, vpcID, testConfig.AWSRegion)
+	vpc := terratestaws.GetVpcById(t, vpcID, testConfig.AWSRegion)
 
 	if nameTag, exists := vpc.Tags["Name"]; exists {
 		common.ValidateResourceNaming(t, nameTag, testConfig.Prefix, "vpc")

--- a/terraform/tests/modules/networking_test.go
+++ b/terraform/tests/modules/networking_test.go
@@ -1,12 +1,17 @@
 package modules
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"terraform-tests/common"
 
-	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	awsgo "github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
 )
@@ -35,7 +40,7 @@ func TestNetworkingModuleCreatesVPCAndSubnets(t *testing.T) {
 	vpcID := terraform.Output(t, terraformOptions, "vpc_id")
 	assert.NotEmpty(t, vpcID)
 
-	vpc := aws.GetVpcById(t, vpcID, testConfig.AWSRegion)
+	vpc := awsgo.GetVpcById(t, vpcID, testConfig.AWSRegion)
 	// Note: VPC detailed validation simplified due to Terratest API limitations
 	assert.NotNil(t, vpc)
 
@@ -225,7 +230,7 @@ func TestNetworkingModuleValidatesResourceNaming(t *testing.T) {
 
 	// Validate VPC naming
 	vpcID := terraform.Output(t, terraformOptions, "vpc_id")
-	vpc := aws.GetVpcById(t, vpcID, testConfig.AWSRegion)
+	vpc := awsgo.GetVpcById(t, vpcID, testConfig.AWSRegion)
 
 	if nameTag, exists := vpc.Tags["Name"]; exists {
 		common.ValidateResourceNaming(t, nameTag, testConfig.Prefix, "vpc")
@@ -238,4 +243,164 @@ func TestNetworkingModuleValidatesResourceNaming(t *testing.T) {
 		// Note: Tag validation simplified - EC2 tags use complex structure
 		assert.NotNil(t, subnet)
 	}
+}
+
+// TestPrivateSubnetRouting verifies that private app subnets have no default route (0.0.0.0/0)
+// and rely solely on VPC endpoints for AWS service access
+func TestPrivateSubnetRouting(t *testing.T) {
+	common.SkipIfShortTest(t)
+
+	testConfig := common.NewTestConfig("../../modules/networking")
+	testVars := common.GetNetworkingTestVars()
+	testVars["create_private_subnets"] = true
+	testVars["create_vpc_endpoints"] = true
+
+	terraformOptions := testConfig.GetModuleTerraformOptions("../../modules/networking", testVars)
+	defer common.CleanupResources(t, terraformOptions)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Get the private app route table ID
+	privateAppRouteTableID := terraform.Output(t, terraformOptions, "private_app_route_table_id")
+	assert.NotEmpty(t, privateAppRouteTableID)
+
+	// Create AWS client to examine route table directly
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(testConfig.AWSRegion))
+	assert.NoError(t, err)
+
+	ec2Client := ec2.NewFromConfig(cfg)
+
+	// Get route table details
+	input := &ec2.DescribeRouteTablesInput{
+		RouteTableIds: []string{privateAppRouteTableID},
+	}
+
+	result, err := ec2Client.DescribeRouteTables(context.TODO(), input)
+	assert.NoError(t, err)
+	assert.Len(t, result.RouteTables, 1)
+
+	routeTable := result.RouteTables[0]
+
+	// Check that no default route (0.0.0.0/0) exists
+	hasDefaultRoute := false
+	for _, route := range routeTable.Routes {
+		if route.DestinationCidrBlock != nil && *route.DestinationCidrBlock == "0.0.0.0/0" {
+			hasDefaultRoute = true
+			break
+		}
+	}
+
+	assert.False(t, hasDefaultRoute, "Private app route table should not have a default route (0.0.0.0/0)")
+
+	// Verify VPC endpoints are created
+	s3EndpointID := terraform.Output(t, terraformOptions, "s3_endpoint_id")
+	assert.NotEmpty(t, s3EndpointID, "S3 VPC endpoint should be created")
+
+	endpointsSecurityGroupID := terraform.Output(t, terraformOptions, "endpoints_security_group_id")
+	assert.NotEmpty(t, endpointsSecurityGroupID, "VPC endpoints security group should be created")
+}
+
+// TestVPCEndpointsConfiguration verifies VPC endpoints are properly configured for private subnet access
+func TestVPCEndpointsConfiguration(t *testing.T) {
+	common.SkipIfShortTest(t)
+
+	testConfig := common.NewTestConfig("../../modules/networking")
+	testVars := common.GetNetworkingTestVars()
+	testVars["create_vpc_endpoints"] = true
+	testVars["create_private_subnets"] = true
+
+	terraformOptions := testConfig.GetModuleTerraformOptions("../../modules/networking", testVars)
+	defer common.CleanupResources(t, terraformOptions)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	vpcID := terraform.Output(t, terraformOptions, "vpc_id")
+
+	// Create AWS client
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(testConfig.AWSRegion))
+	assert.NoError(t, err)
+
+	ec2Client := ec2.NewFromConfig(cfg)
+
+	// Check S3 Gateway endpoint
+	s3EndpointID := terraform.Output(t, terraformOptions, "s3_endpoint_id")
+	if s3EndpointID != "" {
+		s3Input := &ec2.DescribeVpcEndpointsInput{
+			VpcEndpointIds: []string{s3EndpointID},
+		}
+		s3Result, err := ec2Client.DescribeVpcEndpoints(context.TODO(), s3Input)
+		assert.NoError(t, err)
+		assert.Len(t, s3Result.VpcEndpoints, 1)
+
+		s3Endpoint := s3Result.VpcEndpoints[0]
+		assert.Equal(t, vpcID, *s3Endpoint.VpcId)
+		assert.Equal(t, string(types.VpcEndpointTypeGateway), string(s3Endpoint.VpcEndpointType))
+		assert.Contains(t, *s3Endpoint.ServiceName, "s3")
+	}
+
+	// Check interface endpoints
+	interfaceEndpoints := terraform.OutputMap(t, terraformOptions, "interface_endpoints")
+	assert.NotEmpty(t, interfaceEndpoints, "Interface endpoints should be created")
+
+	// Verify expected endpoints exist
+	expectedServices := []string{"ecr_api", "ecr_dkr", "logs", "secretsmanager"}
+	for _, service := range expectedServices {
+		endpointID, exists := interfaceEndpoints[service]
+		assert.True(t, exists, fmt.Sprintf("Interface endpoint for %s should exist", service))
+
+		if endpointID != "" {
+			input := &ec2.DescribeVpcEndpointsInput{
+				VpcEndpointIds: []string{endpointID},
+			}
+			result, err := ec2Client.DescribeVpcEndpoints(context.TODO(), input)
+			assert.NoError(t, err)
+			assert.Len(t, result.VpcEndpoints, 1)
+
+			endpoint := result.VpcEndpoints[0]
+			assert.Equal(t, vpcID, *endpoint.VpcId)
+			assert.Equal(t, string(types.VpcEndpointTypeInterface), string(endpoint.VpcEndpointType))
+			assert.True(t, *endpoint.PrivateDnsEnabled)
+		}
+	}
+}
+
+// TestCostOptimization verifies the design avoids NAT Gateway costs
+func TestCostOptimization(t *testing.T) {
+	common.SkipIfShortTest(t)
+
+	testConfig := common.NewTestConfig("../../modules/networking")
+	testVars := common.GetNetworkingTestVars()
+	testVars["create_private_subnets"] = true
+	testVars["create_vpc_endpoints"] = true
+
+	terraformOptions := testConfig.GetModuleTerraformOptions("../../modules/networking", testVars)
+	defer common.CleanupResources(t, terraformOptions)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	vpcID := terraform.Output(t, terraformOptions, "vpc_id")
+
+	// Create AWS client
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(testConfig.AWSRegion))
+	assert.NoError(t, err)
+
+	ec2Client := ec2.NewFromConfig(cfg)
+
+	// Verify no NAT Gateways exist in this VPC
+	natInput := &ec2.DescribeNatGatewaysInput{
+		Filter: []types.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []string{vpcID},
+			},
+		},
+	}
+
+	natResult, err := ec2Client.DescribeNatGateways(context.TODO(), natInput)
+	assert.NoError(t, err)
+	assert.Empty(t, natResult.NatGateways, "No NAT Gateways should exist - cost optimization through VPC endpoints")
+
+	// Verify VPC endpoints are created as cost-effective alternative
+	s3EndpointID := terraform.Output(t, terraformOptions, "s3_endpoint_id")
+	assert.NotEmpty(t, s3EndpointID, "S3 VPC endpoint should replace NAT Gateway for AWS service access")
 }


### PR DESCRIPTION
- Remove default routes (0.0.0.0/0) from private subnet route table to Internet Gateway
- Private subnets with VPC endpoints should not have internet routes
- ECS tasks with assign_public_ip=false were failing because they tried to route traffic through IGW without public IPs
- Now traffic to AWS services (ECR, CloudWatch, Secrets Manager) goes through VPC endpoints while ALB can still reach tasks in private subnets

This fixes 504 gateway timeouts by ensuring proper private subnet networking without requiring expensive NAT Gateways (~$45/month savings).

🤖 Generated with [Claude Code](https://claude.ai/code)