### PR TITLE
Potential fix for code scanning alert no. 52: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint_prettier.yml
+++ b/.github/workflows/lint_prettier.yml
@@ -1,5 +1,8 @@
 name: Prettier Lint
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/lhadjchikh/coalition-builder/security/code-scanning/52](https://github.com/lhadjchikh/coalition-builder/security/code-scanning/52)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only performs read operations (e.g., checking out code, installing dependencies, and running linting commands), we will set `contents: read` as the permission. This ensures that the workflow has only the necessary access to the repository's contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
