### PR TITLE
Potential fix for code scanning alert no. 43: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint_typescript.yml
+++ b/.github/workflows/lint_typescript.yml
@@ -1,5 +1,8 @@
 name: TypeScript Type Check
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/lhadjchikh/coalition-builder/security/code-scanning/43](https://github.com/lhadjchikh/coalition-builder/security/code-scanning/43)

To fix the issue, add a `permissions` block to the workflow. Since the workflow only needs to read the repository contents to perform the TypeScript type check, the permissions can be set to `contents: read`. This ensures that the `GITHUB_TOKEN` has the least privilege necessary to complete the task.

The `permissions` block should be added at the root of the workflow file, so it applies to all jobs in the workflow. Alternatively, it can be added specifically to the `typecheck` job if other jobs in the workflow require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
